### PR TITLE
localization: Change the Japanese word 値 to テレメトリ

### DIFF
--- a/localization/qgc_ja.ts
+++ b/localization/qgc_ja.ts
@@ -11393,7 +11393,7 @@ Note that this will also completely reset everything, including UAVCAN nodes.</s
     <message>
         <location filename="../src/api/QGCCorePlugin.cc" line="273"/>
         <source>Values</source>
-        <translation>値</translation>
+        <translation>テレメトリ</translation>
     </message>
     <message>
         <location filename="../src/api/QGCCorePlugin.cc" line="274"/>
@@ -14618,7 +14618,7 @@ Confirm change?</source>
     <message>
         <location filename="../src/FlightMap/Widgets/ValuePageWidget.qml" line="40"/>
         <source>Value Widget Setup</source>
-        <translation>値ウィジェットの設定</translation>
+        <translation>テレメトリウィジェットの設定</translation>
     </message>
     <message>
         <location filename="../src/FlightMap/Widgets/ValuePageWidget.qml" line="168"/>


### PR DESCRIPTION
**Describe the bug**
A clear and concise description of the bug.

The telemetry data value display item name on the flight screen is "値".
It is unclear if the "値" is a telemetry value.


**To Reproduce**
Steps to reproduce the behavior:

1. Display the flight screen.

**Expected behavior**
A clear and concise description of what you expected to happen.

1. Item name is "テレメトリ".
2. Item name is "テレメトリウィジェットの設定".

**Log Files and Screenshots**
*Always* add screenshots and the QGC console log.

AFTER
![Screenshot from 2022-02-27 19-50-19](https://user-images.githubusercontent.com/646194/155881551-0b0d25c9-71b2-4f56-9ca8-c60ddde7f5e6.png)

![Screenshot from 2022-02-27 19-50-29](https://user-images.githubusercontent.com/646194/155881569-f6eb6a0e-70ec-491c-8952-62e070b9e15f.png)

**Drone (please complete the following information):**
- Describe the type of drone.
- Photo of the IMU / autopilot setup if possible.

All drones.

**Additional context**
Add any other context about the problem here.

None
