### PR TITLE
Vehicle: "Fence Breached" voice notification using FENCE_STATUS

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1315,6 +1315,7 @@ private:
     void _handleMessageInterval         (const mavlink_message_t& message);
     void _handleGimbalOrientation       (const mavlink_message_t& message);
     void _handleObstacleDistance        (const mavlink_message_t& message);
+    void _handleFenceStatus             (const mavlink_message_t& message);
     // ArduPilot dialect messages
 #if !defined(NO_ARDUPILOT_DIALECT)
     void _handleCameraFeedback          (const mavlink_message_t& message);


### PR DESCRIPTION
I looked at the ArduPilot PR.
HERELINK is not processing FENCE_STATUS messages.
I look at the FENCE_STATUS message and if it crosses the fence, I give an audio notification.
This voice notification repeats in 3 second cycles if the fence is exceeded continuously for more than 3 seconds.

ArduPilot PR:
https://github.com/ArduPilot/ardupilot/pull/20275