### PR TITLE
APM: Change the flight mode list

### DIFF
--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -77,7 +77,6 @@ ArduCopterFirmwarePlugin::ArduCopterFirmwarePlugin(void)
         APMCopterMode(APMCopterMode::FLOWHOLD,      true),
         APMCopterMode(APMCopterMode::FOLLOW,        true),
         APMCopterMode(APMCopterMode::ZIGZAG,        true),
-        APMCopterMode(APMCopterMode::ZIGZAG,        true),
         APMCopterMode(APMCopterMode::SYSTEMID,      true),
         APMCopterMode(APMCopterMode::AUTOROTATE,    true),
         APMCopterMode(APMCopterMode::AUTO_RTL,      true),


### PR DESCRIPTION
I saw two ZIGZAGs appear in the flight mode list on the main toolbar.
I removed one.