### PR TITLE
APM: Add POLYGON to the GEOFENCE setting

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -437,7 +437,7 @@ SetupPage {
                                         _fenceEnable.value = 1
                                         _fenceType.value = 2
                                     }
-                                } else if (altitudeGeo.checked) {
+                                } else if (altitudeGeo.checked || polygonGeo.checked) {
                                     _fenceType.value &= ~2
                                 } else {
                                     _fenceEnable.value = 0
@@ -462,8 +462,33 @@ SetupPage {
                                         _fenceEnable.value = 1
                                         _fenceType.value = 1
                                     }
-                                } else if (circleGeo.checked) {
+                                } else if (circleGeo.checked || polygonGeo.checked) {
                                     _fenceType.value &= ~1
+                                } else {
+                                    _fenceEnable.value = 0
+                                    _fenceType.value = 0
+                                }
+                            }
+                        }
+
+                        QGCCheckBox {
+                            id:                 polygonGeo
+                            anchors.topMargin:  _margins / 2
+                            anchors.left:       altitudeGeo.left
+                            anchors.top:        altitudeGeo.bottom
+                            text:               qsTr("Polygon GeoFence enabled")
+                            checked:            _fenceEnable.value != 0 && _fenceType.value & 4
+
+                            onClicked: {
+                                if (checked) {
+                                    if (_fenceEnable.value == 1) {
+                                        _fenceType.value |= 4
+                                    } else {
+                                        _fenceEnable.value = 1
+                                        _fenceType.value = 4
+                                    }
+                                } else if (circleGeo.checked || altitudeGeo.checked) {
+                                    _fenceType.value &= ~4
                                 } else {
                                     _fenceEnable.value = 0
                                     _fenceType.value = 0
@@ -475,7 +500,7 @@ SetupPage {
                             id:                 geoReportRadio
                             anchors.margins:    _margins
                             anchors.left:       parent.left
-                            anchors.top:        altitudeGeo.bottom
+                            anchors.top:        polygonGeo.bottom
                             text:               qsTr("Report only")
                             checked:            _fenceAction.value == 0
 


### PR DESCRIPTION
If all GEOFENCE settings in the SAFETY item are disabled, the POLYGON fence setting disappears.
Polygon and circle settings in the flight plan screen do not set FENCE_TYPE and FENCE_ENABLE.
I add the POLYGON setting to the GEOFENCE setting in the SAFETY item.


AFTER
![Screenshot from 2022-06-05 08-22-50](https://user-images.githubusercontent.com/646194/172029469-8b972052-6606-4494-ba4b-674b6c499f3a.png)

![Screenshot from 2022-06-05 08-22-40](https://user-images.githubusercontent.com/646194/172029479-e22ca841-f710-47a0-9602-026854b477df.png)

BEFORE
![Screenshot from 2022-06-05 07-40-28](https://user-images.githubusercontent.com/646194/172029435-9ae1c2f9-1328-48e7-b795-95cb036ffdc0.png)

