### PR TITLE
APM: Add fence margin items

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -417,8 +417,8 @@ SetupPage {
 
                     Rectangle {
                         id:     geoFenceSettings
-                        width:  fenceAltMaxField.x + fenceAltMaxField.width + _margins
-                        height: fenceAltMaxField.y + fenceAltMaxField.height + _margins
+                        width:  fenceMarginField.x + fenceMarginField.width + _margins
+                        height: fenceMarginField.y + fenceMarginField.height + _margins
                         color:  ggcPal.windowShade
 
                         QGCCheckBox {
@@ -548,6 +548,23 @@ SetupPage {
                             anchors.left:       fenceAltMaxLabel.right
                             anchors.top:        fenceRadiusField.bottom
                             fact:               _fenceAltMax
+                            showUnits:          true
+                        }
+
+                        QGCLabel {
+                            id:                 fenceMarginLabel
+                            anchors.left:       circleGeo.left
+                            anchors.baseline:   fenceMarginField.baseline
+                            text:               qsTr("Margin:         ")
+                        }
+
+                        FactTextField {
+                            id:                 fenceMarginField
+                            anchors.topMargin:  _margins / 2
+                            anchors.leftMargin: _margins
+                            anchors.left:       fenceMarginLabel.right
+                            anchors.top:        fenceAltMaxField.bottom
+                            fact:               _fenceMargin
                             showUnits:          true
                         }
                     } // Rectangle - GeoFence Settings


### PR DESCRIPTION
I would add a fence margin to the safety geofence item.
I would add a fence margin to this geofence item to make the user aware of the margin.

AFTER
![Screenshot from 2022-06-14 23-18-16](https://user-images.githubusercontent.com/646194/173601614-494f17c7-b971-4d2a-a923-8530e55560b5.png)