### PR TITLE
uas: Converts a plain text string to an HTML string replaced by HTML entities

### DIFF
--- a/src/uas/UASMessageHandler.cc
+++ b/src/uas/UASMessageHandler.cc
@@ -187,7 +187,7 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     if (_multiComp) {
         compString = QString(" COMP:%1").arg(compId);
     }
-    message->_setFormatedText(QString("<font style=\"%1\">[%2%3]%4 %5</font><br/>").arg(style).arg(dateString).arg(compString).arg(severityText).arg(text));
+    message->_setFormatedText(QString("<font style=\"%1\">[%2%3]%4 %5</font><br/>").arg(style).arg(dateString).arg(compString).arg(severityText).arg(text.toHtmlEscaped()));
 
     if (message->severityIsError()) {
         _latestError = severityText + " " + text;
@@ -202,7 +202,7 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     emit textMessageCountChanged(count);
 
     if (_showErrorsInToolbar && message->severityIsError()) {
-        _app->showMessage(message->getText());
+        _app->showMessage(message->getText().toHtmlEscaped());
     }
 }
 


### PR DESCRIPTION
Messages are displayed in HTML format.
ArduPilot uses "<" for IMU heater temperature notification.
The ArduPilot does not display anything below this symbol.
Converts a plain text string to an HTML string with HTML metacharacters <, >, &, and " replaced by HTML entities.

AFTER
![Screenshot from 2023-01-06 23-51-49](https://user-images.githubusercontent.com/646194/211038140-ae289df5-6199-43ea-92c7-c512c21d14f6.png)
![Screenshot from 2023-01-06 23-51-24](https://user-images.githubusercontent.com/646194/211038151-dd567084-bc4b-48b6-9b81-ff824e4dadf0.png)


BEFORE
![Screenshot from 2023-01-06 00-48-36](https://user-images.githubusercontent.com/646194/211038248-c74fd9e2-4c8a-423e-81c2-4cfe54607392.png)
![Screenshot from 2023-01-06 00-48-20](https://user-images.githubusercontent.com/646194/211038262-606513d3-f048-4ac5-b90c-c63d50000c8f.png)