### PR TITLE
VideoStreaming: Enable PC builds

### DIFF
--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -27,7 +27,9 @@
 #include <QDir>
 #include <QDateTime>
 #include <QSysInfo>
+#if defined(__android__)
 #include <AndroidInterface.h>
+#endif
 
 QGC_LOGGING_CATEGORY(VideoReceiverLog, "VideoReceiverLog")
 
@@ -603,7 +605,9 @@ VideoReceiver::_handleStateChanged() {
 void
 VideoReceiver::_handleRecordingChanged() {
     if(!_recording && !_videoFile.isEmpty()) {
+#if defined(__android__)
         AndroidInterface::triggerMediaScannerScanFile(_videoFile);
+#endif
     }
 }
 #endif
@@ -731,7 +735,9 @@ VideoReceiver::startRecording(const QString &videoFile)
     if(videoFile.isEmpty()) {
         QString savePath;
         if (_videoSettings->saveSdCardEnable()->rawValue().toBool()) {
+#if defined(__android__)
             savePath = AndroidInterface::getSdcardPath();
+#endif
             if (!savePath.isEmpty()) {
                 savePath = savePath + "/QGroundControl/Video";
                 QDir savePathDir(savePath);


### PR DESCRIPTION
ANDROID code is enabled in the PC build.
This causes an error in the build.
I made sure to quote it in the preprocessor to make sure it works on the PC.
I have easily verified the operation on PC with this change.