### PR TITLE
Fix HDMI switching

### DIFF
--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -824,9 +824,8 @@ VideoManager::_restartVideo(unsigned id)
 
     if (_videoStarted[id]) {
         _stopReceiver(id);
-    } else {
-        _startReceiver(id);
     }
+    _startReceiver(id);
 #endif
 }
 

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -847,7 +847,7 @@ VideoManager::_startReceiver(unsigned id)
     const unsigned rtsptimeout = _videoSettings->rtspTimeout()->rawValue().toUInt();
     /* The gstreamer rtsp source will switch to tcp if udp is not available after 5 seconds.
        So we should allow for some negotiation time for rtsp */
-    const unsigned timeout = (source == VideoSettings::videoSourceRTSP ? rtsptimeout : 2 );
+    const unsigned timeout = (source == VideoSettings::videoSourceRTSP ? rtsptimeout : 15 );
 
     if (id > 1) {
         qCDebug(VideoManagerLog) << "Unsupported receiver id" << id;


### PR DESCRIPTION
Two fixes that should fix the problem where the stream stops after switching HDMI inputs back and forth a few times.

1. The RTSP client restarts after a timeout and then keeps looping unsuccessfully. Raising the timeout seems to fix this.
2. A receiver restart seems to be potentially doing a stop only and no start. I'm not 100% sure whether this has an influence or not.