### PR TITLE
VideoReceiver: Cap rtspsrc jitterbuffer with drop-on-latency

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
@@ -747,6 +747,12 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
             g_object_set(source,
                          "location", input.toUtf8().constData(),
                          "latency", 25,
+                         // Cap the internal rtpjitterbuffer at `latency` and drop instead of
+                         // letting it grow. Without this, jitterbuffer latency is a floor that
+                         // only ever increases under sender/receiver clock skew, which on some
+                         // air unit firmware revisions (different RTC behaviour) causes video
+                         // lag to accumulate monotonically over time.
+                         "drop-on-latency", TRUE,
                          "protocols", 1,                  // UDP only (GST_RTSP_LOWER_TRANS_UDP)
                          "udp-timeout", G_GUINT64_CONSTANT(10000000), // 10 seconds (15000000 microseconds)
                          nullptr);

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
@@ -110,6 +110,16 @@ void GstVideoReceiver::start(uint32_t timeout)
             break;
         }
 
+        // Live decode path: keep this queue from becoming a second place lag can
+        // accumulate. By default a queue is non-leaky and holds up to 1s, so if
+        // the decoder ever stalls it back-pressures and adds latency. Cap it at
+        // 200ms and leak the oldest buffer on overflow (drop, don't block) so the
+        // newest frames always win and worst-case added latency stays bounded.
+        g_object_set(decoderQueue,
+                     "leaky", 2,                         // GST_QUEUE_LEAK_DOWNSTREAM (drop oldest)
+                     "max-size-time", 200 * GST_MSECOND,
+                     nullptr);
+
         _decoderValve = gst_element_factory_make("valve", nullptr);
         if (!_decoderValve)  {
             qCCritical(GstVideoReceiverLog) << "gst_element_factory_make('valve') failed";


### PR DESCRIPTION
The internal rtpjitterbuffer latency is a floor that only ever grows under sender/receiver clock skew and never shrinks back, so video lag accumulates monotonically. This shows up on some newer air unit firmware revisions (different RTC behaviour) but not others, despite the same QGC pipeline.

The sink is already sync=FALSE, so the accumulation is not at the sink but inside rtspsrc's jitterbuffer. Set drop-on-latency=TRUE to cap it at latency (25ms) and drop rather than grow.
