### PR TITLE
DeviceInfo: Don't block map tiles when reachability is Unknown

### DIFF
--- a/src/Utilities/DeviceInfo.cc
+++ b/src/Utilities/DeviceInfo.cc
@@ -35,7 +35,10 @@ bool isInternetAvailable()
 
     const QNetworkInformation::Reachability reachability = QNetworkInformation::instance()->reachability();
 
-    return (reachability == QNetworkInformation::Reachability::Online);
+    // Treat only a definite disconnect as offline. On some platforms (e.g. Qt 6.6.x
+    // on Android) reachability stays Unknown for a connection established before the
+    // app started, which would otherwise wrongly block all map tile fetches.
+    return (reachability != QNetworkInformation::Reachability::Disconnected);
 }
 
 bool isNetworkEthernet()


### PR DESCRIPTION
isInternetAvailable() required QNetworkInformation::reachability() to be exactly Online. On Qt 6.6.3/Android the reachability stays Unknown for a connection established before the app started, so every map tile fetch was short-circuited with 'Network Not Available' and no request was ever made, even though the network was fully validated and other requests (e.g. version checks) worked. Treat only a definite Disconnected as offline.