### PR TITLE
GPS / remote ID improvements

### DIFF
--- a/src/Comms/LinkManager.cc
+++ b/src/Comms/LinkManager.cc
@@ -526,6 +526,17 @@ void LinkManager::_updateAutoConnectLinks()
 #endif
     } else {
         _nmeaSocket->close();
+#ifndef QGC_NO_SERIAL_LINK
+        // NMEA was switched off (e.g. back to "Disabled"): also tear down any serial NMEA port
+        if (_nmeaPort) {
+            _nmeaPort->close();
+            delete _nmeaPort;
+            _nmeaPort = nullptr;
+            _nmeaDeviceName = "";
+        }
+#endif
+        // Revert QGCPositionManager to the integrated GPS if it was using an NMEA source
+        QGCPositionManager::instance()->resetNmeaSourceDevice();
     }
 
 #ifndef QGC_NO_SERIAL_LINK

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -159,11 +159,18 @@ void QGCPositionManager::_positionUpdated(const QGeoPositionInfo &update)
         }
     }
 
+    // Accept the altitude when the fix carries one and the vertical accuracy is either
+    // acceptable or not reported at all. The Android position source typically reports a
+    // vertical accuracy well above the old 10m gate (or none), which used to drop the
+    // altitude entirely and leave consumers such as Remote ID (which mandates an operator
+    // altitude in FAA regions) with a NaN.
+    bool verticalAccuracyOk = true;
     if (update.hasAttribute(QGeoPositionInfo::VerticalAccuracy)) {
         _gcsPositionVerticalAccuracy = update.attribute(QGeoPositionInfo::VerticalAccuracy);
-        if (_gcsPositionVerticalAccuracy <= kMinVerticalAccuracyMeters) {
-            newGCSPosition.setAltitude(update.coordinate().altitude());
-        }
+        verticalAccuracyOk = (_gcsPositionVerticalAccuracy <= kMinVerticalAccuracyMeters);
+    }
+    if ((update.coordinate().type() == QGeoCoordinate::Coordinate3D) && verticalAccuracyOk) {
+        newGCSPosition.setAltitude(update.coordinate().altitude());
     }
 
     _gcsPositionAccuracy = sqrt(pow(_gcsPositionHorizontalAccuracy, 2) + pow(_gcsPositionVerticalAccuracy, 2));

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -118,6 +118,30 @@ void QGCPositionManager::setNmeaSourceDevice(QIODevice *device)
     _setPositionSource(QGCPositionManager::NmeaGPS);
 }
 
+void QGCPositionManager::resetNmeaSourceDevice()
+{
+    if (!_nmeaSource) {
+        return;
+    }
+
+    const bool wasCurrent = (_currentSource == _nmeaSource);
+
+    _nmeaSource->stopUpdates();
+    (void) disconnect(_nmeaSource);
+    if (wasCurrent) {
+        // Clear so _setPositionSource() doesn't try to touch the source we're about to delete
+        _currentSource = nullptr;
+    }
+
+    delete _nmeaSource;
+    _nmeaSource = nullptr;
+
+    if (wasCurrent) {
+        // Fall back to the platform's default position source (e.g. the integrated Android GPS)
+        _setPositionSource(QGCPositionManager::InternalGPS);
+    }
+}
+
 void QGCPositionManager::_positionUpdated(const QGeoPositionInfo &update)
 {
     _geoPositionInfo = update;

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -96,6 +96,6 @@ private:
     QGCCompass *_compass = nullptr;
 
     static constexpr qreal kMinHorizonalAccuracyMeters = 100.;
-    static constexpr qreal kMinVerticalAccuracyMeters = 10.;
+    static constexpr qreal kMinVerticalAccuracyMeters = 100.;
     static constexpr qreal kMinDirectionAccuracyDegrees = 30.;
 };

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -48,6 +48,9 @@ public:
     int updateInterval() const { return _updateInterval; }
 
     void setNmeaSourceDevice(QIODevice *device);
+    /// Tears down any active NMEA source and falls back to the platform's default
+    /// position source (e.g. the integrated Android GPS).
+    void resetNmeaSourceDevice();
 
 signals:
     void gcsPositionChanged(QGeoCoordinate gcsPosition);

--- a/src/UI/AppSettings/RemoteIDSettings.qml
+++ b/src/UI/AppSettings/RemoteIDSettings.qml
@@ -495,6 +495,7 @@ SettingsPage {
                     fact:                       _fact
                     textField.maximumLength:    20
                     enabled:                    locationTypeFact.rawValue === RemoteIDSettings.LocationType.FIXED
+                    visible:                    locationTypeFact.rawValue === RemoteIDSettings.LocationType.FIXED
                     Layout.fillWidth:           true
                     textFieldPreferredWidth:    textFieldWidth
 
@@ -506,6 +507,7 @@ SettingsPage {
                     fact:                       _fact
                     textField.maximumLength:    20
                     enabled:                    locationTypeFact.rawValue === RemoteIDSettings.LocationType.FIXED
+                    visible:                    locationTypeFact.rawValue === RemoteIDSettings.LocationType.FIXED
                     Layout.fillWidth:           true
                     textFieldPreferredWidth:    textFieldWidth
 
@@ -517,10 +519,39 @@ SettingsPage {
                     fact:                       _fact
                     textField.maximumLength:    20
                     enabled:                    locationTypeFact.rawValue === RemoteIDSettings.LocationType.FIXED
+                    visible:                    locationTypeFact.rawValue === RemoteIDSettings.LocationType.FIXED
                     Layout.fillWidth:           true
                     textFieldPreferredWidth:    textFieldWidth
 
                     property Fact _fact: remoteIDSettings.altitudeFixed
+                }
+
+                // Live position actually being broadcast when not using a fixed location
+                // (Live GNSS uses the GCS position source, e.g. the integrated Android GPS)
+                GridLayout {
+                    Layout.fillWidth:   true
+                    visible:            locationTypeFact.rawValue !== RemoteIDSettings.LocationType.FIXED
+                    columns:            2
+                    columnSpacing:      ScreenTools.defaultFontPixelWidth
+                    rowSpacing:         ScreenTools.defaultFontPixelHeight / 2
+
+                    QGCLabel { text: qsTr("Current Latitude") }
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        text:               gcsPosition.isValid ? gcsPosition.latitude.toFixed(7) : qsTr("Waiting for GPS...")
+                    }
+
+                    QGCLabel { text: qsTr("Current Longitude") }
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        text:               gcsPosition.isValid ? gcsPosition.longitude.toFixed(7) : qsTr("Waiting for GPS...")
+                    }
+
+                    QGCLabel { text: qsTr("Current Altitude") }
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        text:               (gcsPosition.isValid && !isNaN(gcsPosition.altitude)) ? (gcsPosition.altitude.toFixed(1) + qsTr(" m")) : qsTr("N/A")
+                    }
                 }
 
                 GridLayout {

--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -295,33 +295,30 @@ void RemoteIDManager::_sendSystem()
         gcsPosition = QGCPositionManager::instance()->gcsPosition();
         geoPositionInfo = QGCPositionManager::instance()->geoPositionInfo();
 
-        // GPS position needs to be valid before checking other stuff
-        if (geoPositionInfo.isValid()) {
-            // If we dont have altitude for FAA then the GPS data is no good
-            if ((_settings->region()->rawValue().toInt() == Region::FAA) && !(gcsPosition.altitude() >= 0) && _gcsGPSGood) {
-                _gcsGPSGood = false;
-                emit gcsGPSGoodChanged();
-                qCDebug(RemoteIDManagerLog) << "GCS GPS data error (no altitude): Altitude data is mandatory for GCS GPS data in FAA regions.";
-                return;
-            }
+        // Determine GPS health deterministically from the current data every cycle. The
+        // previous code flipped _gcsGPSGood relative to its prior value across separate
+        // checks, which made it oscillate green/red at the send rate (e.g. in FAA when the
+        // altitude was momentarily missing).
+        bool good = true;
+        const char* reason = nullptr;
+        if (!geoPositionInfo.isValid()) {
+            good = false;
+            reason = "GCS GPS data is not valid.";
+        } else if ((_settings->region()->rawValue().toInt() == Region::FAA) && !(gcsPosition.altitude() >= 0)) {
+            // FAA mandates an operator altitude
+            good = false;
+            reason = "GCS GPS data error (no altitude): Altitude data is mandatory for GCS GPS data in FAA regions.";
+        } else if (_lastGeoPositionTimeStamp.msecsTo(QDateTime::currentDateTimeUtc()) > ALLOWED_GPS_DELAY) {
+            good = false;
+            reason = "GCS GPS data is older than 5 seconds";
+        }
 
-            // If the GPS data is older than ALLOWED_GPS_DELAY we cannot use this data
-            if (_lastGeoPositionTimeStamp.msecsTo(QDateTime::currentDateTime().currentDateTimeUtc()) > ALLOWED_GPS_DELAY) {
-                if (_gcsGPSGood) {
-                    _gcsGPSGood = false;
-                    emit gcsGPSGoodChanged();
-                    qCDebug(RemoteIDManagerLog) << "GCS GPS data is older than 5 seconds";
-                }
-            } else {
-                if (!_gcsGPSGood) {
-                    _gcsGPSGood = true;
-                    emit gcsGPSGoodChanged();
-                }
-            }
-        } else {
-            _gcsGPSGood = false;
+        if (good != _gcsGPSGood) {
+            _gcsGPSGood = good;
             emit gcsGPSGoodChanged();
-            qCDebug(RemoteIDManagerLog) << "GCS GPS data is not valid.";
+            if (reason) {
+                qCDebug(RemoteIDManagerLog) << reason;
+            }
         }
 
     }

--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -496,6 +496,10 @@ void RemoteIDManager::setEmergency(bool declare)
 void RemoteIDManager::_updateLastGCSPositionInfo(QGeoPositionInfo update)
 {
     if (update.isValid()) {
-        _lastGeoPositionTimeStamp = update.timestamp().toUTC();
+        // Stamp the local arrival time rather than update.timestamp(). The freshness
+        // check in _sendSystem() compares this against the local wall clock, and on some
+        // platforms (e.g. Android) the position source's own timestamp is offset from the
+        // system clock, which made gcsGPSGood flap green/red even with a healthy fix.
+        _lastGeoPositionTimeStamp = QDateTime::currentDateTimeUtc();
     }
 }


### PR DESCRIPTION
- Properly support disabling NMEA link to switch back to integrated Android GPS.
- Show live GCS position in remote ID tab.