### PR TITLE
Revert release signingConfig (fixes androiddeployqt apk build)

### DIFF
--- a/custom/android/build.gradle
+++ b/custom/android/build.gradle
@@ -82,15 +82,6 @@ android {
         noCompress 'rcc'
     }
 
-    signingConfigs {
-        debug {
-            storeFile file('debug.keystore')
-            storePassword 'android'
-            keyAlias 'androiddebugkey'
-            keyPassword 'android'
-        }
-    }
-
     defaultConfig {
         resConfig "en"
         minSdkVersion qtMinSdkVersion
@@ -107,12 +98,6 @@ android {
         println "ndk.abiFilters: ${ndk.abiFilters}"
         println "versionCode: ${versionCode}"
         println "versionName: ${versionName}"
-    }
-
-    buildTypes {
-        release {
-            signingConfig signingConfigs.debug
-        }
     }
 
     println "timestamp: " + getTimestampStr()


### PR DESCRIPTION
The gradle release `signingConfig` added in `80673bbbd` conflicts with androiddeployqt and prevents `QGroundControl-v5.apk` from being produced.

## Problem
With `signingConfig signingConfigs.debug` on the release buildType, gradle signs the apk itself and emits `android-build-release.apk` (no `-unsigned` variant). androiddeployqt expects the **unsigned** gradle output for its own zipalign+sign (or copy) step, so it fails:

- signed path (`QT_ANDROID_SIGN_APK=ON`): `zipalign command failed` on missing `android-build-release-unsigned.apk`
- unsigned path: exit 20, no apk copied

Result: `cmake --build` fails at the "Creating APK" step even though gradle reports `BUILD SUCCESSFUL`.

## Fix
Revert the signingConfig. Signing is handled by androiddeployqt via `QT_ANDROID_SIGN_APK=ON` + the `QT_ANDROID_KEYSTORE_*` env vars, which is what CI already does. Mainline `Stable_V5.0` never carried this signingConfig, so this realigns the Herelink line with it.

## Local build note
Local builds should now sign the CI way, e.g. with the debug keystore:
```sh
export QT_ANDROID_KEYSTORE_PATH=$PWD/android/debug.keystore
export QT_ANDROID_KEYSTORE_ALIAS=androiddebugkey
export QT_ANDROID_KEYSTORE_STORE_PASS=android
export QT_ANDROID_KEYSTORE_KEY_PASS=android
# qt-cmake ... -DQT_ANDROID_SIGN_APK=ON
```

## Testing
Verified locally (Qt 6.6.3, build-tools 35.0.0): with the revert + the env above, androiddeployqt produces a debug-signed, verifying `QGroundControl-v5.apk`.